### PR TITLE
fix: move to lazy rule evaluation to prevent .message() from overwriting violations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.8.0</version>
+            <version>3.27.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/joseph/rule/Rule.java
+++ b/src/main/java/com/joseph/rule/Rule.java
@@ -24,27 +24,32 @@ public abstract class Rule<T, R extends Rule<T, R>> {
      * Value to validate
      */
     protected final T value;
+
     /**
      * Field name
      */
     protected final String fieldName;
+
     /**
      * List of violations
      */
-    protected final List<String> violations = new ArrayList<>();
+    private final List<String> violations = new ArrayList<>();
+
     /**
      * Internal representation of a validation rule.
      * Encapsulates the logic (predicate) and the resulting error message.
+     * @param <T> Type of the value to validate
      */
     private static class Constraint<T> {
-        Predicate<T> predicate;
-        String message;
+        private final Predicate<T> predicate;
+        private String message;
 
-        Constraint(Predicate<T> predicate, String message) {
+        Constraint(final Predicate<T> predicate, final String message) {
             this.predicate = predicate;
             this.message = message;
         }
     }
+
     /**
      * Collection of constraints to be evaluated lazily.
      */
@@ -55,7 +60,7 @@ public abstract class Rule<T, R extends Rule<T, R>> {
      * @param predicate The condition to test (returns true if invalid)
      * @param message The error message if the predicate is true
      */
-    protected void addConstraint(Predicate<T> predicate, String message) {
+    protected void addConstraint(final Predicate<T> predicate, final String message) {
         constraints.add(new Constraint<>(predicate, message));
     }
 
@@ -225,10 +230,10 @@ public abstract class Rule<T, R extends Rule<T, R>> {
     public List<String> getViolations() {
         if (violations.isEmpty()) {
             violations.addAll(
-                constraints.stream()
-                    .filter(constraint -> constraint.predicate.test(value))
-                    .map(constraint -> constraint.message)
-                    .toList()
+                    constraints.stream()
+                        .filter(constraint -> constraint.predicate.test(value))
+                        .map(constraint -> constraint.message)
+                        .toList()
             );
         }
         return violations;

--- a/src/main/java/com/joseph/rule/child/DateRule.java
+++ b/src/main/java/com/joseph/rule/child/DateRule.java
@@ -22,7 +22,7 @@ public class DateRule extends Rule<LocalDate, DateRule> {
      * @return the current rule
      */
     public DateRule isFuture() {
-        if (value != null && !value.isAfter(LocalDate.now())) violations.add("must be a future date");
+        addConstraint(val -> val != null && !val.isAfter(LocalDate.now()), "must be a future date");
         return this;
     }
 
@@ -31,7 +31,7 @@ public class DateRule extends Rule<LocalDate, DateRule> {
      * @return the current rule
      */
     public DateRule isPast() {
-        if (value != null && !value.isBefore(LocalDate.now())) violations.add("must be a past date");
+        addConstraint(val -> val != null && !val.isBefore(LocalDate.now()), "must be a past date");
         return this;
     }
 }

--- a/src/main/java/com/joseph/rule/child/NumberRule.java
+++ b/src/main/java/com/joseph/rule/child/NumberRule.java
@@ -23,9 +23,7 @@ public class NumberRule extends Rule<Number, NumberRule> {
      * @return NumberRule
      */
     public NumberRule min(final Number min) {
-        if (value != null && value.doubleValue() < min.doubleValue()) {
-            violations.add("must be at least " + min);
-        }
+        addConstraint(val -> val != null && val.doubleValue() < min.doubleValue(), "must be at least " + min);
         return this;
     }
 
@@ -35,9 +33,7 @@ public class NumberRule extends Rule<Number, NumberRule> {
      * @return NumberRule
      */
     public NumberRule max(final Number max) {
-        if (value != null && value.doubleValue() > max.doubleValue()) {
-            violations.add("must be at most " + max);
-        }
+        addConstraint(val -> val != null && val.doubleValue() > max.doubleValue(), "must be at most " + max);
         return this;
     }
 }

--- a/src/main/java/com/joseph/rule/child/ObjectRule.java
+++ b/src/main/java/com/joseph/rule/child/ObjectRule.java
@@ -37,9 +37,7 @@ public class ObjectRule<T> extends Rule<T, ObjectRule<T>> {
      * @return the current rule
      */
     public ObjectRule<T> minSize(final int min) {
-        if (value instanceof java.util.Collection<?> col && col.size() < min) {
-            violations.add("must have at least " + min + " items");
-        }
+        addConstraint(val -> val instanceof java.util.Collection<?> col && col.size() < min, "must have at least " + min + " items");
         return this;
     }
 
@@ -49,9 +47,7 @@ public class ObjectRule<T> extends Rule<T, ObjectRule<T>> {
      * @return the current rule
      */
     public ObjectRule<T> maxSize(final int max) {
-        if (value instanceof java.util.Collection<?> col && col.size() > max) {
-            violations.add("must have at most " + max + " items");
-        }
+        addConstraint(val -> val instanceof java.util.Collection<?> col && col.size() > max, "must have at most " + max + " items");
         return this;
     }
 

--- a/src/main/java/com/joseph/rule/child/StringRule.java
+++ b/src/main/java/com/joseph/rule/child/StringRule.java
@@ -24,7 +24,7 @@ public class StringRule extends Rule<String, StringRule> {
      * @return StringRule
      */
     public StringRule notBlank() {
-        if (value != null && value.isBlank()) violations.add("must not be blank");
+        addConstraint(val -> val != null && val.isBlank(), "must not be blank");
         return this;
     }
 
@@ -33,7 +33,7 @@ public class StringRule extends Rule<String, StringRule> {
      * @return StringRule
      */
     public StringRule email() {
-        if (value != null && !EMAIL_REGEX.matcher(value).matches()) violations.add("must be a valid email");
+        addConstraint(val -> val != null && !EMAIL_REGEX.matcher(val).matches(), "must be a valid email");
         return this;
     }
 
@@ -43,7 +43,7 @@ public class StringRule extends Rule<String, StringRule> {
      * @return StringRule
      */
     public StringRule matches(final String regex) {
-        if (value != null && !Pattern.matches(regex, value)) violations.add("must match pattern " + regex);
+        addConstraint(val -> val != null && !Pattern.matches(regex, val), "must match pattern " + regex);
         return this;
     }
 
@@ -54,7 +54,7 @@ public class StringRule extends Rule<String, StringRule> {
      * @return StringRule
      */
     public StringRule length(final int min, final int max) {
-        if (value != null && (value.length() < min || value.length() > max)) violations.add("must be between " + min + " and " + max + " characters");
+        addConstraint(val -> val != null && (val.length() < min || val.length() > max), "must be between " + min + " and " + max + " characters");
         return this;
     }
 

--- a/src/test/java/com/joseph/rule/child/NumberRuleTest.java
+++ b/src/test/java/com/joseph/rule/child/NumberRuleTest.java
@@ -211,4 +211,24 @@ class NumberRuleTest {
             });
     }
 
+    @Test
+    void shouldOverrideMessage_WhenMultipleMessagesAppliedToSameRule() {
+        record TestRecord(Integer someIntegerField) {
+            TestRecord {
+                RecordRules.check(
+                    Rule.on(someIntegerField, "someIntegerField").required()
+                        .message("must be provided")
+                        .message("is a required field")
+                );
+            }
+        }
+        assertThatThrownBy(() -> new TestRecord(null))
+            .isInstanceOf(RecordValidationException.class)
+            .satisfies(ex -> {
+                var errors = ((RecordValidationException) ex).getErrors().get("someIntegerField");
+                assertEquals(1, errors.size());
+                assertEquals("is a required field", errors.get(0));
+            });
+    }
+
 }

--- a/src/test/java/com/joseph/rule/child/NumberRuleTest.java
+++ b/src/test/java/com/joseph/rule/child/NumberRuleTest.java
@@ -222,6 +222,7 @@ class NumberRuleTest {
                 );
             }
         }
+
         assertThatThrownBy(() -> new TestRecord(null))
             .isInstanceOf(RecordValidationException.class)
             .satisfies(ex -> {

--- a/src/test/java/com/joseph/rule/child/NumberRuleTest.java
+++ b/src/test/java/com/joseph/rule/child/NumberRuleTest.java
@@ -1,11 +1,15 @@
 package com.joseph.rule.child;
 
+import com.joseph.RecordRules;
+import com.joseph.exception.RecordValidationException;
 import com.joseph.rule.Rule;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 class NumberRuleTest {
@@ -171,4 +175,40 @@ class NumberRuleTest {
         assertNotNull(rule);
         assertEquals("count", rule.getFieldName());
     }
+
+    @Test
+    void shouldThrowAndContainBothMessages_ForNumberRule_WithSeparateAssertions() {
+        record TestRecord(Integer age) {
+            TestRecord {
+                RecordRules.check(
+                    Rule.on(age, "age")
+                        .min(10).message("Too young")
+                        .max(15).message("Too old")
+                );
+            }
+        }
+
+        assertThatThrownBy(() -> new TestRecord(5))
+            .isInstanceOf(RecordValidationException.class)
+            .satisfies(ex -> {
+                var errors = ((RecordValidationException) ex)
+                    .getErrors()
+                    .get("age");
+
+                assertThat(String.join(" ", errors))
+                    .containsIgnoringCase("Too young");
+            });
+
+        assertThatThrownBy(() -> new TestRecord(25))
+            .isInstanceOf(RecordValidationException.class)
+            .satisfies(ex -> {
+                var errors = ((RecordValidationException) ex)
+                    .getErrors()
+                    .get("age");
+
+                assertThat(String.join(" ", errors))
+                    .containsIgnoringCase("Too old");
+            });
+    }
+
 }

--- a/src/test/java/com/joseph/rule/child/StringRuleTest.java
+++ b/src/test/java/com/joseph/rule/child/StringRuleTest.java
@@ -149,4 +149,26 @@ class StringRuleTest {
             });
     }
 
+    @Test
+    void shouldMaintainSeparateMessages_ForMultipleRules() {
+        record TestRecord(String someStringField) {
+            TestRecord {
+                RecordRules.check(
+                    Rule.on(someStringField, "someStringField")
+                        .length(5, 10).message("Must be between 5 and 10 characters")
+                        .minLength(5).message("Must be at least 5 characters")
+                );
+            }
+        }
+
+        assertThatThrownBy(() -> new TestRecord("ABC"))
+            .isInstanceOf(RecordValidationException.class)
+            .satisfies(ex -> {
+                var errors = ((RecordValidationException) ex).getErrors().get("someStringField");
+                assertEquals(2, errors.size());
+                assertThat(errors.get(0)).isEqualTo("Must be between 5 and 10 characters");
+                assertThat(errors.get(1)).isEqualTo("Must be at least 5 characters");
+            });
+    }
+
 }


### PR DESCRIPTION
Addresses #2 with lazy evaluation approach.

**The Problem:** The `.message()` method was mutating the violation list eagerly. If a rule in a fluent chain passed, its .message() call would accidentally pop and replace the error message of a previous failing rule, leading to incorrect error reporting.

**The Solution:** Transitioned from an Eager to a Lazy validation model.

- Introduced a `Constraint` class to store the predicate and message without executing them immediately.
- Rule methods like eg `minLength()` now only register constraints.
- The `.message()` method now modifies the metadata of the last registered constraint.
- Actual validation execution is deferred to a single pass within `getViolations()`, ensuring deterministic results and fixing the state corruption.